### PR TITLE
Add archival notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+> [!WARNING]
+> **Repository archived**
+>
+> This repository has been archived following the CAMARA **Lifecycle Clean-up Process** and is kept for reference / maintenance of previous releases only.
+>
+> - Decision record (API Backlog/TSC): [APIBacklog#284](https://github.com/camaraproject/APIBacklog/issues/284)
+> - Lifecycle policy: [Unified Clean-up Process](https://github.com/camaraproject/Governance/blob/main/documentation/API-Onboarding-and-Lifecycle.md#unified-clean-up-process-for-inactive-onboarding-trackers-and-repositories)
+> - Reason or Phase of the process: [Phase C – Repository With Partial Progress](https://github.com/camaraproject/Governance/blob/main/documentation/API-Onboarding-and-Lifecycle.md#archival-criteria-per-phase)
+> - Request reactivation: submit a new issue in APIBacklog referencing this archived repository: [Reactivation of archived repositories](https://github.com/camaraproject/Governance/blob/main/documentation/API-Onboarding-and-Lifecycle.md#reactivation-of-archived-repositories)
+
 <a href="https://github.com/camaraproject/SiteToCloudVPN/commits/" title="Last Commit"><img src="https://img.shields.io/github/last-commit/camaraproject/SiteToCloudVPN?style=plastic"></a>
 <a href="https://github.com/camaraproject/SiteToCloudVPN/issues" title="Open Issues"><img src="https://img.shields.io/github/issues/camaraproject/SiteToCloudVPN?style=plastic"></a>
 <a href="https://github.com/camaraproject/SiteToCloudVPN/pulls" title="Open Pull Requests"><img src="https://img.shields.io/github/issues-pr/camaraproject/SiteToCloudVPN?style=plastic"></a>


### PR DESCRIPTION
Add standard archival warning to README.md as required by the [Lifecycle Clean-up Process](https://github.com/camaraproject/Governance/blob/main/documentation/API-Onboarding-and-Lifecycle.md#archived-repository-communication-requirements).

Decision record: camaraproject/APIBacklog#284
Phase: C – Repository With Partial Progress